### PR TITLE
Readd BepInEx support (see BananaModInfo PR #1)

### DIFF
--- a/BananaModManager/FormMain.cs
+++ b/BananaModManager/FormMain.cs
@@ -220,7 +220,7 @@ namespace MonkeModManager
                     }
                     else
                     {
-                        if (!release.Name.Contains("MelonLoader"))
+                        if (!release.Name.Contains("MelonLoader") && !release.Name.Contains("BepInEx"))
                         {
                             UnzipFile(file, (release.InstallLocation != null) ? Path.Combine(InstallDirectory, release.InstallLocation) : InstallDirectory);
                         }
@@ -229,10 +229,12 @@ namespace MonkeModManager
                             UnzipFile(file, InstallDirectory);
 
                             // necessary MelonLoader folders
-                            Directory.CreateDirectory(InstallDirectory + @"\Mods");
-                            Directory.CreateDirectory(InstallDirectory + @"\Plugins");
-                            Directory.CreateDirectory(InstallDirectory + @"\UserData");
-                            Directory.CreateDirectory(InstallDirectory + @"\UserLibs");
+                            if (release.Name.Contains("MelonLoader") {
+                                Directory.CreateDirectory(InstallDirectory + @"\Mods");
+                                Directory.CreateDirectory(InstallDirectory + @"\Plugins");
+                                Directory.CreateDirectory(InstallDirectory + @"\UserData");
+                                Directory.CreateDirectory(InstallDirectory + @"\UserLibs");
+                            }
                         }
                     }
                     UpdateStatus(string.Format("Installed {0}!", release.Name));

--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 
 This program will install custom mods into Capuchin automatically, and can be re-run in order to update the mods
 
-The program currently supports
-
+The program currently supports both Capuchin-compatable mod loaders:
 * [BepInEx](https://github.com/BepInEx/BepInEx) by **The BepInEx Team**
-
+* [MelonLoader](https://github.com/LavaGang/MelonLoader) by **LavaGang**
 
 This uses the github api to get the latest release of all these mods, so you know you'll always be getting the latest version!
 (If you've made a mod that you want added to the installer, send us a message on Discord! `thelinuxtrans` `devpixel`)


### PR DESCRIPTION
https://github.com/DeveloperPixel0/BananaModInfo/pull/1

BepInEx mod loader works just fine with Capuchin (contrary to what most believe), so this will readd
BepInEx 6 installer support to BananaModManager.